### PR TITLE
Add support for mutable variables.

### DIFF
--- a/Notes.md
+++ b/Notes.md
@@ -1,0 +1,22 @@
+## Notes
+
+### Mutable Variables
+- Must be in SSA form
+- We are going to use the `mem2reg` LLVM IR optimizer, instead of inserting PHI nodes directly.
+- `mem2reg` promotes `alloca`s into registers, inserting PHI nodes where necessary.
+- Looking at `alloca` code with the `opt` tool and `mem2reg`, we can see how it transforms the code: `llvm-as < example.ll | opt -mem2reg | llvm-dis`
+
+1. Each mutable variable becomes a stack allocation.
+2. Each read of the variable becomes a load from the stack.
+3. Each update of the variable becomes a store to the stack.
+4. Taking the address of a variable just uses the stack address directly.
+
+#### mem2reg caveats
+- mem2reg is alloca-driven: it looks for allocas and if it can handle them, it promotes them. It does not apply to global variables or heap allocations.
+- mem2reg only looks for alloca instructions in the entry block of the function. Being in the entry block guarantees that the alloca is only executed once, which makes analysis simpler.
+- mem2reg only promotes allocas whose uses are direct loads and stores. If the address of the stack object is passed to a function, or if any funny pointer arithmetic is involved, the alloca will not be promoted.
+- mem2reg only works on allocas of first class values (such as pointers, scalars and vectors), and only if the array size of the allocation is 1 (or missing in the .ll file). mem2reg is not capable of promoting structs or arrays to registers. Note that the “scalarrepl” pass is more powerful and can promote structs, “unions”, and arrays in many cases.
+
+#### Additional language features required:
+- The ability to mutate variables with the ‘=’ operator.
+- The ability to define new variables.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## yorkie [![Build Status](https://travis-ci.org/daniel-beard/yorkie.svg)](https://travis-ci.org/daniel-beard/yorkie)
 - yorkie is a toy ~~dog~~ language, implemented as a learning experience.
-- It is in *not* intended for actual use.
+- It is *not* intended for actual use.
 - Based on the LLVM tutorial: http://llvm.org/docs/tutorial/LangImpl1.html
 
 ### Language Syntax
@@ -53,6 +53,7 @@ fib(40)
 
 ### TODO
 - [ ] Finish chapters
+- [ ] Chapter 7, the CreateArgumentAllocas method no longer exists in the full code listing, it should be updated to reflect that the code is just added to the function::codegen() instead.
 - [ ] Refactor out into different classes, e.g. Lexer, Parser, CodeGen, etc.
 - [ ] Function definitions should have commas between parameters
 - [ ] If statements should support multiple expressions
@@ -69,7 +70,8 @@ fib(40)
 - [X] Chapter 4: Adding JIT and optimizer support 
 - [X] Chapter 5: Extending the language: control flow 
 - [X] Chapter 6: Extending the language: user-defined operators
-- [ ] Chapter 7: Extending the language: Mutable Variables.
+- [X] Chapter 7: Extending the language: Mutable Variables.
+- [ ] Chapter 8: Adding debug information
 
 ### References / Links
 - http://llvm.org/docs/LangRef.html contains references to other interesting instructions that should be relatively easy to add to this language.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ def fib(x)
 
 # This expression will compute the 40th number.
 fib(40)
+
+# Mutable variables
+def foo()
+    var x = 10 in 
+        x = 11
 ```
 
 ### Building
@@ -61,6 +66,9 @@ fib(40)
 - [ ] If statements should have an `if/end` variant (without `else`).
 - [ ] If statements should have an `elseif` variant
 - [ ] Add examples folder
+- [ ] Add types
+- [ ] Add arrays
+- [ ] Add simple string type (array of chars)
 - [ ] Add mandlebrot renderer - http://llvm.org/docs/tutorial/LangImpl6.html#kicking-the-tires
 
 ### Progress


### PR DESCRIPTION
- Using alloca's and mem2reg, we avoid having to manually insert PHI nodes everywhere.
- We use stack memory (store and load) instead of assigning registers directly.
